### PR TITLE
Add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-setuptools
-pip
-docopt
 delphixpy
+docopt
+pip
 python-dateutil
+setuptools
+untangle


### PR DESCRIPTION
Using the currently outline requirements some files fail:
```
Traceback (most recent call last):
  File "delphix_admin_setup.py", line 17, in <module>
    import untangle
ImportError: No module named untangle
```