### PR TITLE
Add unitttest to tox.ini file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ The two main autoformatters that we use are
  - `black`: General Python formatting
  - `isort`: Import sorting
 
+
+### Unittests
+
+The unittests are run through the `tox` tool. To run in Python2 run:
+```
+tox -e py27
+```
+
+To run in Python3 run:
+```
+tox -e py36
+```
+
 ## Statement of Support
 
 This software is provided as-is, without warranty of any kind or

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,14 @@
 [tox]
-envlist = format
+envlist = format, py27, py36
 skipsdist = True
+
+[testenv]
+commands = pytest --log-level=DEBUG -n 4 --cov=delphixpy-examples --cov-report term --cov-report html tests/ {posargs}
+deps =
+    -rrequirements.txt
+    pytest
+    pytest-cov
+    pytest-xdist
 
 [testenv:format]
 description = Format the code base to adhere to our styles, and complain about what we cannot do automatically


### PR DESCRIPTION
# Problem

There is not a documented way to run the unittests in `tests/`

# Solution

Add the `pytest` runner to our `tox` configuration. This allows us to run `tox -e py27` to run the Python2 tests.

# Issues that need to be resolved before merging

Every single test fails with
```
No route to host
```

Is there some configuration that we should mention needs to be set before we can run the tests?