### PR TITLE
Use implicit line continuations instead of explicit

### DIFF
--- a/delphix_will_plugin.py
+++ b/delphix_will_plugin.py
@@ -39,8 +39,10 @@ class DelphixPlugin(WillPlugin):
     @respond_to("snapshot (?P<v_object>.*)")
     def snapshot_databases_will(self, message, v_object=None):
         if " in " not in v_object:
-            will_response = "Please specify group with request. For example:\n \
-            snapshot Employee Oracle 11G DB in Sources"
+            will_response = (
+                "Please specify group with request. For example:\n"
+                "snapshot Employee Oracle 11G DB in Sources"
+            )
             self.reply(message, will_response)
         else:
             v_object = v_object.split(" in ", 1)
@@ -82,8 +84,10 @@ class DelphixPlugin(WillPlugin):
     @respond_to("delete vdb (?P<v_object>.*)")
     def delete_databases_will(self, message, v_object=None):
         if " in " not in v_object:
-            will_response = "Please specify group with request. For example:\n \
-            delete Employee Oracle 11G DB in Sources"
+            will_response = (
+                "Please specify group with request. For example:\n"
+                "delete Employee Oracle 11G DB in Sources"
+            )
             self.reply(message, will_response)
         else:
             v_object = v_object.split(" in ", 1)
@@ -112,8 +116,10 @@ class DelphixPlugin(WillPlugin):
     @respond_to("refresh vdb (?P<v_object>.*)")
     def refresh_vdbs_will(self, message, v_object=None):
         if " in " not in v_object:
-            will_response = "Please specify group with request. For example:\n \
-            refresh autoprod in Analytics"
+            will_response = (
+                "Please specify group with request. For example:\n"
+                "refresh autoprod in Analytics"
+            )
             self.reply(message, will_response)
         else:
             v_object = v_object.split(" in ", 1)
@@ -144,8 +150,11 @@ class DelphixPlugin(WillPlugin):
     @respond_to("refresh jetstream (?P<v_object>.*)")
     def refresh_jetstream_will(self, message, v_object=None):
         if " in " not in v_object:
-            will_response = "Please specify group with request. For example:\n \
-            refresh jetstream Sugar Automated Testing Container in Masked SugarCRM Application"
+            will_response = (
+                "Please specify group with request. For example:\n"
+                "refresh jetstream Sugar Automated Testing Container in"
+                " Masked SugarCRM Application"
+            )
             self.reply(message, will_response)
         else:
             v_object = v_object.split(" in ", 1)

--- a/dx_refresh_db.py
+++ b/dx_refresh_db.py
@@ -701,13 +701,10 @@ def run_job(engine):
                 engine = dxtools_objects[arguments["--engine"]]
                 print_info("Executing against Delphix Engine: " + arguments["--engine"])
             except:
-                print_error(
-                    'Delphix Engine "'
-                    + arguments["--engine"]
-                    + '" \
-                            cannot be found in '
-                    + config_file_path
-                )
+                print_error('Delphix Engine "{}" cannot be found in "{}"'.format(
+                    arguments["--engine"],
+                    config_file_path,
+                ))
                 print_error("Please check your value and try again. Exiting")
                 sys.exit(1)
 

--- a/dx_refresh_vdb.py
+++ b/dx_refresh_vdb.py
@@ -171,9 +171,9 @@ def refresh_database(vdb_name, timestamp, timestamp_type="SNAPSHOT"):
             # OracleRefreshParameters
             """
             rewind_params = RollbackParameters()
-            rewind_params.timeflow_point_parameters = \
-            dx_timeflow_obj.set_timeflow_point(container_obj, timestamp_type,
-                                               timestamp)
+            rewind_params.timeflow_point_parameters = dx_timeflow_obj.set_timeflow_point(
+                container_obj, timestamp_type, timestamp
+            )
             print_debug('{}: {}'.format(engine_name, str(rewind_params)))
             """
             if str(container_obj.reference).startswith("ORACLE"):

--- a/lib/GetSession.py
+++ b/lib/GetSession.py
@@ -98,8 +98,7 @@ class GetSession(object):
 
         #        if use_https:
         #            if hasattr(ssl, '_create_unverified_context'):
-        #                ssl._create_default_https_context = \
-        #                    ssl._create_unverified_context
+        #                ssl._create_default_https_context = ssl._create_unverified_context
 
         try:
             if f_engine_password:

--- a/via_httplib.py
+++ b/via_httplib.py
@@ -12,7 +12,7 @@ import sys
 import urllib
 from argparse import RawTextHelpFormatter
 
-SCRIPT_DESCRIPTION = """\
+SCRIPT_DESCRIPTION = """
 Connect to Delphix engine to run some queries using the http lib library
 """
 


### PR DESCRIPTION
# Problem

We use backslashes for line continuations. This makes the code harder to read

# Solution

Use implicit line continuations instead of backslashes