### PR TITLE
Add isort autoformatter to Python3 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dxtools.conf*
 venv
 .DS_Store
 **/.idea
+.tox/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+force_single_line=True
+known_first_party=delphixpy,lib
+default_section=THIRDPARTY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21
+  hooks:
+    - id: isort

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # delphixpy-examples
-These are some example python scripts for those getting started 
+These are some example python scripts for those getting started
 with the Delphix delphixpy python module.
 
 ## Changes in this Branch
-- This branch requires Python3. All enhancements and break fixes will be committed to this branch and will eventually become the ``master`` branch.
-- We have a new format for dxtools.conf. If you used this repo in the past, please be aware of the new format.
-- All connections use HTTPS by default. Please refer to lib/get\_session.py if using this repo in a production environment.
+- This branch requires Python3. All enhancements and break fixes will
+  be committed to this branch and will eventually become the
+  ``master`` branch.
+- We have a new format for dxtools.conf. If you used this repo in the
+  past, please be aware of the new format.
+- All connections use HTTPS by default. Please refer to
+  lib/get\_session.py if using this repo in a production environment.
 - Migrated from Delphix API version 1.8.0 to 1.10.2.
 
 ## Wait... What's Delphix?
@@ -42,7 +46,18 @@ community page](https://community.delphix.com)
 3.  Add tests for your code.
 4.  Send a pull request.
 
-Contributions must be signed as `User Name <user@email.com>`. Make sure to [set up Git with user name and email address](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup). Bug fixes should branch from the current stable branch
+Contributions must be signed as `User Name <user@email.com>`. Make
+sure to [set up Git with user name and email
+address](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup). Bug
+fixes should branch from the current stable branch
+
+### Formatting
+
+This repository uses the `tox` and `pre-commit` tools to run
+autoformatters on the entire repository. These two tools are the
+industry standard for Python. The goal of these formatters is to
+delegate issues of formatting to the machine so that develeopers and
+code-reviewers can focus on more important things.
 
 ## Something neat worth noting
 Each of the scripts leverage

--- a/dx_delete_vdb.py
+++ b/dx_delete_vdb.py
@@ -42,20 +42,20 @@ Options:
   -v --version              Show version.
 """
 
-from os.path import basename
 import sys
 import time
+from os.path import basename
+
 import docopt
 
 from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import database
 from delphixpy.v1_10_2.web import vo
-
 from lib import dlpx_exceptions
-from lib import dx_timeflow
-from lib import get_session
-from lib import get_references
 from lib import dx_logging
+from lib import dx_timeflow
+from lib import get_references
+from lib import get_session
 from lib import run_job
 from lib.run_async import run_async
 

--- a/dx_environment.py
+++ b/dx_environment.py
@@ -83,20 +83,20 @@ Options:
 
 """
 
-from os.path import basename
 import sys
 import time
+from os.path import basename
+
 import docopt
 
 from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import environment
 from delphixpy.v1_10_2.web import host
 from delphixpy.v1_10_2.web import vo
-
 from lib import dlpx_exceptions
+from lib import dx_logging
 from lib import get_references
 from lib import get_session
-from lib import dx_logging
 from lib import run_job
 from lib.run_async import run_async
 

--- a/dx_provision_dsource.py
+++ b/dx_provision_dsource.py
@@ -143,24 +143,24 @@ Options:
   -v --version              Show version.
 """
 import sys
-from os.path import basename
 import time
+from os.path import basename
+
 import docopt
 
 from delphixpy.v1_10_2 import exceptions
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2.web import environment
-from delphixpy.v1_10_2.web import sourceconfig
-from delphixpy.v1_10_2.web import job
 from delphixpy.v1_10_2.web import database
+from delphixpy.v1_10_2.web import environment
 from delphixpy.v1_10_2.web import group
-
+from delphixpy.v1_10_2.web import job
+from delphixpy.v1_10_2.web import sourceconfig
+from delphixpy.v1_10_2.web import vo
 from lib import dlpx_exceptions
+from lib import dsource_link_ase
+from lib import dsource_link_mssql
+from lib import dx_logging
 from lib import get_references
 from lib import get_session
-from lib import dx_logging
-from lib import dsource_link_mssql
-from lib import dsource_link_ase
 from lib import run_job
 from lib.run_async import run_async
 

--- a/dx_refresh_vdb.py
+++ b/dx_refresh_vdb.py
@@ -57,20 +57,20 @@ Options:
   -v --version              Show version.
 """
 
-from os.path import basename
 import sys
 import time
+from os.path import basename
+
 import docopt
 
 from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import database
 from delphixpy.v1_10_2.web import vo
-
 from lib import dlpx_exceptions
-from lib import dx_timeflow
-from lib import get_session
-from lib import get_references
 from lib import dx_logging
+from lib import dx_timeflow
+from lib import get_references
+from lib import get_session
 from lib import run_job
 from lib.run_async import run_async
 

--- a/dx_rewind_vdb.py
+++ b/dx_rewind_vdb.py
@@ -53,20 +53,20 @@ Options:
   -v --version              Show version.
 """
 
-from os.path import basename
 import sys
 import time
+from os.path import basename
+
 import docopt
 
+from delphixpy.v1_8_0.web import vo
 from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import database
-from delphixpy.v1_8_0.web import vo
-
 from lib import dlpx_exceptions
-from lib import dx_timeflow
-from lib import get_session
-from lib import get_references
 from lib import dx_logging
+from lib import dx_timeflow
+from lib import get_references
+from lib import get_session
 from lib import run_job
 from lib.run_async import run_async
 

--- a/lib/dsource_link.py
+++ b/lib/dsource_link.py
@@ -2,10 +2,9 @@
 Create an object to link MS SQL or ASE dSources
 """
 
-from delphixpy.v1_10_2.web import sourceconfig
 from delphixpy.v1_10_2.web import group
+from delphixpy.v1_10_2.web import sourceconfig
 from delphixpy.v1_10_2.web import vo
-
 from lib import dlpx_exceptions
 from lib import get_references
 

--- a/lib/dsource_link_ase.py
+++ b/lib/dsource_link_ase.py
@@ -3,14 +3,13 @@
 Link an ASE Sybase dSource
 """
 from delphixpy.v1_10_2 import exceptions
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2.web import environment
 from delphixpy.v1_10_2.web import database
+from delphixpy.v1_10_2.web import environment
 from delphixpy.v1_10_2.web import repository
-
-from lib.dsource_link import DsourceLink
+from delphixpy.v1_10_2.web import vo
 from lib import dlpx_exceptions
 from lib import get_references
+from lib.dsource_link import DsourceLink
 
 VERSION = "v.0.3.000"
 

--- a/lib/dsource_link_mssql.py
+++ b/lib/dsource_link_mssql.py
@@ -3,13 +3,12 @@
 Link a MSSQL dSource
 """
 from delphixpy.v1_10_2 import exceptions
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2.web import environment
 from delphixpy.v1_10_2.web import database
-
-from lib.dsource_link import DsourceLink
+from delphixpy.v1_10_2.web import environment
+from delphixpy.v1_10_2.web import vo
 from lib import dlpx_exceptions
 from lib import get_references
+from lib.dsource_link import DsourceLink
 
 VERSION = "v.0.3.000"
 

--- a/lib/dx_timeflow.py
+++ b/lib/dx_timeflow.py
@@ -7,16 +7,15 @@ import sys
 from distutils.version import LooseVersion
 
 from delphixpy.v1_10_2 import exceptions
+from delphixpy.v1_10_2 import job_context
+from delphixpy.v1_10_2.web import database
 from delphixpy.v1_10_2.web import snapshot
 from delphixpy.v1_10_2.web import timeflow
-from delphixpy.v1_10_2.web import database
-from delphixpy.v1_10_2 import job_context
-from delphixpy.v1_10_2.web.timeflow import bookmark
 from delphixpy.v1_10_2.web import vo
-
+from delphixpy.v1_10_2.web.timeflow import bookmark
 from lib import dlpx_exceptions
-from lib import get_references
 from lib import dx_logging
+from lib import get_references
 
 VERSION = "v.0.3.000"
 

--- a/lib/get_references.py
+++ b/lib/get_references.py
@@ -3,18 +3,18 @@ Module that provides lookups of references and names of Delphix objects.
 """
 
 from datetime import datetime
+
 from dateutil import tz
 
-from delphixpy.v1_10_2.web.service import time
 from delphixpy.v1_10_2 import exceptions
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2.web import job
-from delphixpy.v1_10_2.web import source
-from delphixpy.v1_10_2.web import repository
-from delphixpy.v1_10_2.web import sourceconfig
 from delphixpy.v1_10_2.web import database
 from delphixpy.v1_10_2.web import group
-
+from delphixpy.v1_10_2.web import job
+from delphixpy.v1_10_2.web import repository
+from delphixpy.v1_10_2.web import source
+from delphixpy.v1_10_2.web import sourceconfig
+from delphixpy.v1_10_2.web import vo
+from delphixpy.v1_10_2.web.service import time
 from lib import dlpx_exceptions
 
 VERSION = 'v.0.3.002'

--- a/lib/get_session.py
+++ b/lib/get_session.py
@@ -9,15 +9,14 @@
 """
 
 import json
-import ssl
 import os
+import ssl
 from time import sleep
 
-from delphixpy.v1_10_2.delphix_engine import DelphixEngine
-from delphixpy.v1_10_2 import web
 from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2 import job_context
-
+from delphixpy.v1_10_2 import web
+from delphixpy.v1_10_2.delphix_engine import DelphixEngine
 from lib import dlpx_exceptions
 from lib import dx_logging
 

--- a/lib/run_job.py
+++ b/lib/run_job.py
@@ -5,9 +5,8 @@ import time
 
 from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import job
-
-from lib import dx_logging
 from lib import dlpx_exceptions
+from lib import dx_logging
 
 
 def run_job(main_func, dx_obj, engine='default', single_thread=True):

--- a/ss_bookmark.py
+++ b/ss_bookmark.py
@@ -66,22 +66,21 @@ Options:
   -h --help                   Show this screen.
   -v --version                Show version.
 """
-from os.path import basename
 import sys
 import time
+from os.path import basename
+
 import docopt
 
+from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import selfservice
 from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2 import exceptions
-
 from lib import dlpx_exceptions
-from lib import get_session
-from lib import get_references
 from lib import dx_logging
+from lib import get_references
+from lib import get_session
 from lib import run_job
 from lib.run_async import run_async
-
 
 VERSION = 'v.0.3.002'
 

--- a/ss_branch.py
+++ b/ss_branch.py
@@ -57,20 +57,20 @@ Options:
   -v --version              Show version.
 """
 
-from os.path import basename
-import sys
 import re
+import sys
 import time
+from os.path import basename
+
 import docopt
 
+from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import selfservice
 from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2 import exceptions
-
 from lib import dlpx_exceptions
-from lib import get_session
-from lib import get_references
 from lib import dx_logging
+from lib import get_references
+from lib import get_session
 from lib import run_job
 from lib.run_async import run_async
 

--- a/ss_container.py
+++ b/ss_container.py
@@ -68,21 +68,21 @@ Options:
   -h --help                  Show this screen.
   -v --version               Show version.
 """
-from os.path import basename
 import sys
 import time
+from os.path import basename
+
 from docopt import docopt
 
-from delphixpy.v1_10_2.web import selfservice
+from delphixpy.v1_10_2 import exceptions
 from delphixpy.v1_10_2.web import database
+from delphixpy.v1_10_2.web import selfservice
 from delphixpy.v1_10_2.web import user
 from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2 import exceptions
-
 from lib import dlpx_exceptions
-from lib import get_session
-from lib import get_references
 from lib import dx_logging
+from lib import get_references
+from lib import get_session
 from lib import run_job
 from lib.run_async import run_async
 

--- a/ss_template.py
+++ b/ss_template.py
@@ -51,20 +51,20 @@ Options:
   -v --version              Show version.
 """
 
-from os.path import basename
 import sys
 import time
+from os.path import basename
+
 from docopt import docopt
 
-from delphixpy.v1_10_2.web import selfservice
-from delphixpy.v1_10_2.web import database
-from delphixpy.v1_10_2.web import vo
 from delphixpy.v1_10_2 import exceptions
-
+from delphixpy.v1_10_2.web import database
+from delphixpy.v1_10_2.web import selfservice
+from delphixpy.v1_10_2.web import vo
 from lib import dlpx_exceptions
-from lib import get_session
-from lib import get_references
 from lib import dx_logging
+from lib import get_references
+from lib import get_session
 from lib import run_job
 from lib.run_async import run_async
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import glob
+import subprocess
+import time
+
+python_files = glob.glob("*.py")
+for path in (path for path in python_files if path != "test.py"):
+    start = time.time()
+    out = subprocess.call(
+        ["python", path, "-h"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    end = time.time()
+    print("| {} | {} | {} |".format(path, out, end - start))

--- a/tests/test_dx_refresh_vdb.py
+++ b/tests/test_dx_refresh_vdb.py
@@ -4,17 +4,17 @@
 Unit tests for VDB refresh
 """
 
-import unittest
-import sys
 import io
-
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2 import exceptions
-from delphixpy.v1_10_2.web import selfservice
+import sys
+import unittest
 
 import dx_refresh_vdb
-from lib.get_session import GetSession
+
+from delphixpy.v1_10_2 import exceptions
+from delphixpy.v1_10_2.web import selfservice
+from delphixpy.v1_10_2.web import vo
 from lib.dx_timeflow import DxTimeflow
+from lib.get_session import GetSession
 
 VERSION = '0.0.0.1'
 

--- a/tests/test_js_bookmarks.py
+++ b/tests/test_js_bookmarks.py
@@ -4,10 +4,11 @@
 Unit tests for Jet Stream delphixpy
 """
 
-import unittest
 import sys
+import unittest
 
 import js_bookmark
+
 from lib.GetSession import GetSession
 
 VERSION = '0.0.0.1'

--- a/tests/test_lib_dxtimeflow.py
+++ b/tests/test_lib_dxtimeflow.py
@@ -4,21 +4,20 @@
 Unit tests for DPP Timeflows
 """
 
-import unittest
-import types
-from io import StringIO
 import sys
+import types
+import unittest
+from io import StringIO
 
 from delphixpy.v1_10_2.web import database
-from delphixpy.v1_10_2.web import snapshot
 from delphixpy.v1_10_2.web import objects
+from delphixpy.v1_10_2.web import snapshot
 from delphixpy.v1_10_2.web import timeflow
 from delphixpy.v1_10_2.web import vo
-
-from lib.get_session import GetSession
-from lib.dx_timeflow import DxTimeflow
-from lib import get_references
 from lib import dlpx_exceptions
+from lib import get_references
+from lib.dx_timeflow import DxTimeflow
+from lib.get_session import GetSession
 
 VERSION = "v.0.3.001"
 

--- a/tests/test_lib_get_references.py
+++ b/tests/test_lib_get_references.py
@@ -4,15 +4,14 @@
 Unit tests for DPP Timeflows
 """
 
-import unittest
-import types
-from io import StringIO
 import sys
+import types
+import unittest
+from io import StringIO
 
 from delphixpy.v1_10_2 import web
-
-from lib.get_session import GetSession
 from lib import get_references
+from lib.get_session import GetSession
 
 
 class GetReferencesTests(unittest.TestCase):

--- a/tests/test_lib_get_session.py
+++ b/tests/test_lib_get_session.py
@@ -4,17 +4,16 @@
 Unit tests for DPP GetSession
 """
 
-import unittest
-import types
-from io import StringIO
-import sys
 import os
 import ssl
+import sys
+import types
+import unittest
+from io import StringIO
 
 from delphixpy.v1_10_2.web import database
-
-from lib.get_session import GetSession
 from lib import get_references
+from lib.get_session import GetSession
 
 
 class GetSessionTests(unittest.TestCase):

--- a/tests/test_lib_run_job.py
+++ b/tests/test_lib_run_job.py
@@ -4,17 +4,16 @@
 Unit tests for DPP run_job
 """
 
-import unittest
-import types
-import sys
 import os
 import ssl
+import sys
+import types
+import unittest
 from io import StringIO
 
 from delphixpy.v1_10_2 import web
-
-from lib.get_session import GetSession
 from lib.dx_timeflow import DxTimeflow
+from lib.get_session import GetSession
 from lib.run_job import run_job
 
 

--- a/tests/test_ss_bookmark.py
+++ b/tests/test_ss_bookmark.py
@@ -4,16 +4,16 @@
 Unit tests for Self Service bookmark
 """
 
-import unittest
-import sys
 import io
-
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2.web import selfservice
+import sys
+import unittest
 
 import ss_bookmark
-from lib.get_session import GetSession
+
+from delphixpy.v1_10_2.web import selfservice
+from delphixpy.v1_10_2.web import vo
 from lib.dx_timeflow import DxTimeflow
+from lib.get_session import GetSession
 
 VERSION = '0.0.0.1'
 

--- a/tests/test_ss_bookmarks.py
+++ b/tests/test_ss_bookmarks.py
@@ -4,10 +4,11 @@
 Unit tests for Jet Stream delphixpy
 """
 
-import unittest
 import sys
+import unittest
 
 import js_bookmark
+
 from lib.GetSession import GetSession
 
 VERSION = '0.0.0.1'

--- a/tests/test_ss_container.py
+++ b/tests/test_ss_container.py
@@ -4,17 +4,17 @@
 Unit tests for Self Service container
 """
 
-import unittest
-import sys
 import io
-
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2 import exceptions
-from delphixpy.v1_10_2.web import selfservice
+import sys
+import unittest
 
 import ss_container
-from lib.get_session import GetSession
+
+from delphixpy.v1_10_2 import exceptions
+from delphixpy.v1_10_2.web import selfservice
+from delphixpy.v1_10_2.web import vo
 from lib.dx_timeflow import DxTimeflow
+from lib.get_session import GetSession
 
 VERSION = '0.0.0.1'
 

--- a/tests/test_ss_template.py
+++ b/tests/test_ss_template.py
@@ -4,17 +4,17 @@
 Unit tests for Self Service template
 """
 
-import unittest
-import sys
 import io
-
-from delphixpy.v1_10_2.web import vo
-from delphixpy.v1_10_2 import exceptions
-from delphixpy.v1_10_2.web import selfservice
+import sys
+import unittest
 
 import ss_template
-from lib.get_session import GetSession
+
+from delphixpy.v1_10_2 import exceptions
+from delphixpy.v1_10_2.web import selfservice
+from delphixpy.v1_10_2.web import vo
 from lib.dx_timeflow import DxTimeflow
+from lib.get_session import GetSession
 
 VERSION = '0.0.0.1'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = format
+skipsdist = True
+
+[testenv:format]
+description = Format the code base to adhere to our styles, and complain about what we cannot do automatically
+basepython = python3
+deps =
+     pre-commit
+skip_install = True
+commands = pre-commit run {posargs}


### PR DESCRIPTION
# Problem

This is similar to the diff on master that added isort. We would like our Python imports to be properly sorted

# Solution

Add `tox` and `precommit` to run `isort`